### PR TITLE
Github Actionsを追加して自動でビルド/デプロイできるようにした

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,64 @@
+name: Build
+
+on:
+  workflow_call:
+    secrets: # workflow_call の時に secrets の扱いに若干ハマった https://docs.github.com/ja/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_callsecrets
+      WORKLOAD_IDENTITY_PROVIDER:
+        required: true
+      SERVICE_ACCOUNT:
+        required: true
+      IMAGE_TAG_BASE:
+        required: true
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.head_ref || github.ref }}"
+  cancel-in-progress: true
+
+env:
+  WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
+  SERVICE_ACCOUNT: ${{ secrets.SERVICE_ACCOUNT }}
+  IMAGE_HOST: "asia-northeast1-docker.pkg.dev"
+  IMAGE_TAG_BASE: ${{ secrets.IMAGE_TAG_BASE }} # 例. プロジェクトID/artifact_registry名/イメージ名
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: "read"
+      id-token: "write"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - id: "auth"
+        name: "Authenticate to Google Cloud"
+        uses: "google-github-actions/auth@v1"
+        with:
+          workload_identity_provider: ${{ env.WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ env.SERVICE_ACCOUNT }}
+
+      - name: "Set up Cloud SDK"
+        uses: "google-github-actions/setup-gcloud@v1"
+
+      - name: Docker Setup
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Authorize Docker push
+        id: authorize-docker-push
+        shell: bash
+        run: gcloud auth configure-docker ${{ env.IMAGE_HOST }}
+
+      - name: Docker Image Build and Push
+        id: docker-build
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          provenance: false
+          tags: "${{ env.IMAGE_HOST }}/${{ env.IMAGE_TAG_BASE }}:latest"
+          build-args: |
+            APP_VERSION=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/deploy-to-cloud-run.yml
+++ b/.github/workflows/deploy-to-cloud-run.yml
@@ -1,0 +1,110 @@
+name: Deploy to Cloud Run
+
+on:
+  workflow_call:
+    secrets: # workflow_call の時に secrets の扱いに若干ハマった https://docs.github.com/ja/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_callsecrets
+      WORKLOAD_IDENTITY_PROVIDER:
+        required: true
+      SERVICE_ACCOUNT:
+        required: true
+      RUN_SERVICE_ACCOUNT:
+        required: true
+      PROJECT_ID:
+        required: true
+      IMAGE_TAG_BASE:
+        required: true
+      DATABASE_URL:
+        required: true
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.head_ref || github.ref }}"
+  cancel-in-progress: true
+
+env:
+  PROJECT_ID: ${{ secrets.PROJECT_ID }}
+  WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
+  SERVICE_ACCOUNT: ${{ secrets.SERVICE_ACCOUNT }}
+  RUN_SERVICE_ACCOUNT: ${{ secrets.RUN_SERVICE_ACCOUNT }}
+  VPC_CONNECTOR: "vpc-con"
+  GCP_REGION: asia-northeast1
+  GCP_CLOUD_RUN_SERVICE_NAME: "api"
+  IMAGE_HOST: "asia-northeast1-docker.pkg.dev"
+  IMAGE_TAG_BASE: ${{ secrets.IMAGE_TAG_BASE }}
+  DATABASE_URL: ${{ secrets.DATABASE_URL }}
+
+jobs:
+  migrate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checktout
+        uses: actions/checkout@v3
+
+      - id: "auth"
+        name: "Authenticate to Google Cloud"
+        uses: "google-github-actions/auth@v1"
+        with:
+          workload_identity_provider: ${{ env.WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ env.SERVICE_ACCOUNT }}
+
+      - name: "Set up Cloud SDK"
+        uses: "google-github-actions/setup-gcloud@v1"
+        with:
+          install_components: "beta"
+
+      - name: "Run migration"
+        id: migrate
+        run: |
+          gcloud config set run/region $GCP_REGION
+          set +e
+          gcloud beta run jobs describe migration --quiet >/dev/null
+          job_exists_check=$?
+          set -e
+          if [ $job_exists_check -eq 0 ]; then
+            jobs_cmd="update"
+          else
+            jobs_cmd="create"
+          fi
+          echo ": $jobs_cmd a job"
+
+          gcloud beta run jobs $jobs_cmd migration --image="${{ env.IMAGE_HOST }}/${{ env.IMAGE_TAG_BASE }}:latest" --max-retries=1 --args="yarn,prisma,migrate,reset,-f" --service-account="$RUN_SERVICE_ACCOUNT" --vpc-connector="$VPC_CONNECTOR" --set-secrets="DATABASE_URL=DATABASE_URL:latest"
+          gcloud beta run jobs execute migration --wait --format=json
+
+  deploy:
+    runs-on: ubuntu-latest
+
+    needs:
+      - migrate
+
+    permissions:
+      contents: "read"
+      id-token: "write"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - id: "auth"
+        name: "Authenticate to Google Cloud"
+        uses: "google-github-actions/auth@v1"
+        with:
+          workload_identity_provider: ${{ env.WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ env.SERVICE_ACCOUNT }}
+
+      - name: "Set up Cloud SDK"
+        uses: "google-github-actions/setup-gcloud@v1"
+
+      - name: CloudRun Deploy
+        id: deploy
+        uses: google-github-actions/deploy-cloudrun@v1
+        with:
+          project_id: ${{ env.PROJECT_ID }}
+          image: ${{ env.IMAGE_HOST }}/${{ env.IMAGE_TAG_BASE }}:latest
+          region: ${{ env.GCP_REGION }}
+          service: ${{ env.GCP_CLOUD_RUN_SERVICE_NAME }}
+          flags: |
+            --concurrency=200
+            --max-instances=10
+            --min-instances=1
+            --cpu=1
+            --memory=640Mi
+          secrets: DATABASE_URL=DATABASE_URL:latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,32 @@
+name: "build-deploy"
+on:
+  # push:
+  #   branches:
+  #     - "main"
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: write
+  pull-requests: write
+
+jobs:
+  build-image:
+    uses: ./.github/workflows/build-image.yml
+    secrets:
+      # 例. projects/<プロジェクト番号>/locations/global/workloadIdentityPools/<プールID>/providers/github
+      # projects/999999999999/locations/global/workloadIdentityPools/my-pool-id/providers/github
+      WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
+      SERVICE_ACCOUNT: ${{ secrets.SERVICE_ACCOUNT }} # 例. "deploy@example.iam.gserviceaccount.com"
+      IMAGE_TAG_BASE: ${{ secrets.IMAGE_TAG_BASE }} # 例. プロジェクトID/artifact_registry名/イメージ名
+
+  deploy-to-cloud-run:
+    uses: ./.github/workflows/deploy-to-cloud-run.yml
+    needs: build-image
+    secrets:
+      WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
+      SERVICE_ACCOUNT: ${{ secrets.SERVICE_ACCOUNT }}
+      RUN_SERVICE_ACCOUNT: ${{ secrets.RUN_SERVICE_ACCOUNT }}
+      PROJECT_ID: ${{ secrets.PROJECT_ID }}
+      IMAGE_TAG_BASE: ${{ secrets.IMAGE_TAG_BASE }}
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}


### PR DESCRIPTION
前に書いた記事そのまま追加した

[NestJS \+ Prisma のアプリケーションを Github Actions でGCP環境にデプロイするぞ](https://zenn.dev/monicle/articles/4f46306aa4bc3e)