### PR TITLE
遅延ロードやめて eager load に変更

### DIFF
--- a/apps/frontend/app/page.tsx
+++ b/apps/frontend/app/page.tsx
@@ -11,7 +11,7 @@ export default async function Home() {
   return (
     <div className='flex justify-center'>
       <div className='flex flex-col md:gap-8 gap-2 md:p-20 px-2 pt-4 max-w-[900px]'>
-        <Image src="/assets/kv-001.avif" alt="kv" width={900} height={600} className='rounded-lg' />
+        <Image loading='eager' src="/assets/kv-001.avif" alt="kv" width={900} height={600} className='rounded-lg' />
         <div>
           <h1 className="text-2xl md:text-3xl font-bold text-textBlack pb-4">全域</h1>
           <p className='font-bold text-textBlack'>{data.meshis.length}件</p>


### PR DESCRIPTION
related https://github.com/shimabukuromeg/graphql-yoga-sample/pull/24

遅延ロードやめろって書いてるのでやめた

![image](https://github.com/shimabukuromeg/graphql-yoga-sample/assets/10894015/68228dde-3251-481f-94cd-fbd335d99372)

変更前のスコア

![image](https://github.com/shimabukuromeg/graphql-yoga-sample/assets/10894015/a6cacabc-afdb-411d-b94f-ecc2df60aed8)


# 参考


[Largest Contentful Paint を最適化する  \|  Articles  \|  web\.dev](https://web.dev/articles/optimize-lcp?hl=ja#how-to-optimize-each-part)

[Components: <Image> \| Next\.js](https://nextjs.org/docs/app/api-reference/components/image#loading)

[<img>: 画像埋め込み要素 \- HTML: ハイパーテキストマークアップ言語 \| MDN](https://developer.mozilla.org/ja/docs/Web/HTML/Element/img#loading)