### PR TITLE
リストの最初の10件の画像を eager loading にした

### DIFF
--- a/apps/frontend/app/page.tsx
+++ b/apps/frontend/app/page.tsx
@@ -11,7 +11,7 @@ export default async function Home() {
   return (
     <div className='flex justify-center'>
       <div className='flex flex-col md:gap-8 gap-2 md:p-20 px-2 pt-4 max-w-[900px]'>
-        <Image loading='eager' src="/assets/kv-001.avif" alt="kv" width={900} height={600} className='rounded-lg' />
+        {/* <Image loading='eager' src="/assets/kv-001.avif" alt="kv" width={900} height={600} className='rounded-lg' /> */}
         <div>
           <h1 className="text-2xl md:text-3xl font-bold text-textBlack pb-4">全域</h1>
           <p className='font-bold text-textBlack'>{data.meshis.length}件</p>
@@ -20,7 +20,7 @@ export default async function Home() {
           <div className="grid grid-cols-2 md:grid-cols-3 gap-1">
             {
               data.meshis.map((meshi, i) => (
-                <MeshiCard meshi={meshi} key={i} />
+                <MeshiCard meshi={meshi} key={i} isEager={i <= 10} />
               ))
             }
           </div>

--- a/apps/frontend/components/meshi-card.tsx
+++ b/apps/frontend/components/meshi-card.tsx
@@ -28,6 +28,7 @@ export const MeshiCardFragment = graphql(`
 
 type Props = {
     meshi: FragmentType<typeof MeshiCardFragment>
+    isEager?: boolean
 }
 
 export const MeshiCard = (props: Props) => {
@@ -41,6 +42,7 @@ export const MeshiCard = (props: Props) => {
                     height={300}
                     src={meshi.imageUrl}
                     alt=""
+                    loading={props.isEager ? 'eager' : 'lazy'}
                 />
             </Link>
         </>


### PR DESCRIPTION
LCPを上げるために、以下の２つPRでわかりやすいメインコンテンツ配置 & eager laoding にする変更を加えたが、変更前のリスト形式のUIでも初期表示の画面で描画される件数分の画像を eager loading にすれば LCP 改善する説を試す

https://github.com/shimabukuromeg/graphql-yoga-sample/pull/24
https://github.com/shimabukuromeg/graphql-yoga-sample/pull/25


before

#25 での最後の結果の画面キャプチャ

![image](https://github.com/shimabukuromeg/graphql-yoga-sample/assets/10894015/78f087fe-f48a-4151-b265-1bece81a8359)
