### PR TITLE
chore: Enable lock file maintenance with automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,12 @@
     {
       "matchPackageNames": ["eslint"],
       "enabled": false
+    },
+    {
+      "lockFileMaintenance": {
+        "enabled": true,
+        "automerge": true
+      }
     }
   ]
 }


### PR DESCRIPTION
lock file maintenance を自動マージするようにした

The lowest risk type of update to automerge is probably lockFileMaintenance. When Renovate performs lock file maintenance, it leaves the project dependency definitions unchanged, but refreshes the lock file completely so that the latest versions according to the package file constraints are installed.

https://docs.renovatebot.com/key-concepts/automerge/#automerge-non-major-updates


